### PR TITLE
Fix "edit this page" link at the bottom of docs

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -58,7 +58,7 @@ module.exports = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
-          editUrl: 'https://github.com/lexiconhq/lexicon',
+          editUrl: 'https://github.com/lexiconhq/lexicon/blob/master/documentation/',
           routeBasePath: '/',
         },
         theme: {


### PR DESCRIPTION
# Type of PR
- [x] Bug fix (_non-breaking change which fixes an issue_)

# Description

The edit link on the documentation site does not work. When you click on it, it takes you to Github with a white screen which just says "Not found".

### **Changes**

This PR fixes the edit link for all of the documentation so that it includes the branch and takes users to the correct file.

## **Additional Screenshots**

N/A

## Additional information/context

N/A
