### PR TITLE
Fix quickstart command

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "start": "expo start",
-    "quickstart": "expo r -c",
+    "quickstart": "expo -c",
     "typecheck": "tsc --noEmit -p .",
     "format": "prettier --write \"src/**/*.{ts,tsx}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx}\"",


### PR DESCRIPTION
# Type of PR

- [x] Bug fix (_non-breaking change which fixes an issue_)
- [ ] New feature (_adding a feature following a feature-request issue_)
- [ ] Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)
- [ ] Refactor (_rewriting existing code without any feature change_)
- [ ] (!) This change is or requires a documentation update

# Description

Prior to this PR running the following:

```
yarn
yarn generate
yarn quickstart
```

Gave the following:

```
yarn run v1.22.19
$ concurrently --kill-others "yarn --cwd api quickstart" "yarn --cwd frontend quickstart"
$ yarn generate && cross-env PROSE_DISCOURSE_HOST=https://meta.discourse.org PROSE_APP_HOSTNAME=0.0.0.0 PROSE_APP_PORT=8929 ts-node-dev --no-notify --respawn --transpile-only src/index.ts
$ expo r -c
[1] Invalid project root: /home/simon/git/human-compatible-monorepo/third-party/lexicon/frontend/r
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
[1] yarn --cwd frontend quickstart exited with code 1
--> Sending SIGTERM to other processes..
$ yarn generate:schema
[0] yarn --cwd api quickstart exited with code SIGTERM
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

### **Changes**

(is all of this PR template really necessary for 1-line change PRs?)

<details>
<summary>Date: Tuesday, 4 July 2023

Removed `r` from quickstart
</summary>

</details>

## **Additional Screenshots**

## Additional information/context

