### PR TITLE
Ensure that Github Actions runs on alpha-v2 as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, alpha-v2]
   pull_request:
-    branches: [master]
+    branches: [master, alpha-v2]
 
 jobs:
   build:


### PR DESCRIPTION
# Type of PR
Improvement (_improving an existing feature - includes `style:` and `perf:`commits_)

# Description

Upon receiving our first PR to `alpha-v2` #44, it became apparent that GH Actions was not configured to run for `alpha-v2`. 

### **Changes**

<details>
<summary>Thursday, August 17, 2023</summary>

#### **Contextual Changes:**

- Add `alpha-v2` to the list of branches

</details>

## **Additional Screenshots**

N/A

## Additional information/context

This will only be necessary until we fully launch v2. At that point, it could be removed.
